### PR TITLE
Fix embed for Firefox

### DIFF
--- a/lib/vr.js
+++ b/lib/vr.js
@@ -160,7 +160,6 @@ vr.Runtime.prototype.createEmbed_ = function() {
   embed.type = 'application/x-vnd-vr';
   embed.width = 4;
   embed.height = 4;
-  embed.hidden = true;
   embed.style.visibility = 'hidden';
   embed.style.width = '0';
   embed.style.height = '0';


### PR DESCRIPTION
I'm running Firefox Aurora (22.0a2) and the plugin would not load itself if the embed element was set as hidden. Removing the hidden flag fixes this.
