### PR TITLE
Left- and Right-Eye adjustment matrices were backwards.

### DIFF
--- a/lib/vr.js
+++ b/lib/vr.js
@@ -1971,9 +1971,9 @@ vr.StereoParams.prototype.update = function(info) {
   eyeR.distortionCenterOffsetY = 0;
 
   vr.mat4f.makeIdentity(eyeL.viewAdjustMatrix);
-  eyeL.viewAdjustMatrix[12] = interpupillaryDistance / 2;
+  eyeL.viewAdjustMatrix[12] = -interpupillaryDistance / 2;
   vr.mat4f.makeIdentity(eyeR.viewAdjustMatrix);
-  eyeR.viewAdjustMatrix[12] = -interpupillaryDistance / 2;
+  eyeR.viewAdjustMatrix[12] = interpupillaryDistance / 2;
 
   // eye proj = proj offset * proj center
   var projMatrix = this.tmpMat4s_[0];


### PR DESCRIPTION
I tested with all the examples and my project (where the 3D is intentionally more pronounced).  Somewhat difficult to tell with the examples because the distances are so large that any 3D effect (or lack thereof) is subtle.  However, you can see it easier if you increase the IPD to a value around 1.
![Before & After](https://f.cloud.github.com/assets/592215/2216606/fcecce06-9a0d-11e3-80fb-2dd64d8f2aff.jpg)
